### PR TITLE
warn about changing name of ibm-entitlement-key

### DIFF
--- a/src/pages/tutorials/mm/aimgr-install/index.mdx
+++ b/src/pages/tutorials/mm/aimgr-install/index.mdx
@@ -50,6 +50,8 @@ oc project cp4waiops
 
 Next, issue the following command to create the secret:
 
+**Important:** Do not change the name of the secret, you must use the name _ibm-entitlement-key_
+
 ```sh
  oc create secret docker-registry ibm-entitlement-key --docker-username=cp --docker-password=\<your entitlement key\> --docker-server=cp.icr.io --namespace=cp4waiops
 ```


### PR DESCRIPTION
Warn people to use the required key name for aimgr. Secrets not named 'ibm-entitlement-key' will result in the warning:

Warning: spec.imagePullSecret is required to be
    ibm-entitlement-key otherwise it may result in certain workloads being
    unable to access their images.

Signed-off-by: Ryan Hay <ryanhay@au.ibm.com>