### PR TITLE
add internal software download link to Turbonomic labs

### DIFF
--- a/labs/turbonomic/install-lab/2-lab-environment/index.mdx
+++ b/labs/turbonomic/install-lab/2-lab-environment/index.mdx
@@ -42,11 +42,12 @@ To complete this lab you will need:
   > IBM Business Partners can get a trial Turbonomic License from
   > [IBM Passport Advantage](https://www.ibm.com/software/passportadvantage/pao_download_software.html)
   >
-  > IBMers can follow the same instructions but use the internal downloads site
+  > IBMers can follow the same instructions but use the
+  > [internal downloads](https://w3.ibm.com/w3publisher/software-downloads) site
+  > instead.
   >
-  > - Sign in to
-  >   [IBM Passport Advantage](https://www.ibm.com/software/passportadvantage/pao_download_software.html)
-  >   and select Software download
+  > - Sign in to the appropriate link as mentioned above and select Software
+  >   download
   >
   > - Search for "_IBM Turbonomic Application Resource Management On-Prem_" and
   >   select the latest version.

--- a/labs/turbonomic/policies-and-taking-actions-lab/2-lab-environment/index.mdx
+++ b/labs/turbonomic/policies-and-taking-actions-lab/2-lab-environment/index.mdx
@@ -43,11 +43,11 @@ To complete this lab you will need:
   > IBM Business Partners can get a trial Turbonomic License from
   > [IBM Passport Advantage](https://www.ibm.com/software/passportadvantage/pao_download_software.html)
   >
-  > IBMers can follow the same instructions but use the internal downloads site
+  > IBMers can follow the same instructions but use the
+  > [internal downloads](https://w3.ibm.com/w3publisher/software-downloads) site
   >
-  > - Sign in to
-  >   [IBM Passport Advantage](https://www.ibm.com/software/passportadvantage/pao_download_software.html)
-  >   and select Software download
+  > - Sign in to the appropriate link as mentioned above and select Software
+  >   download
   >
   > - Search for "_IBM Turbonomic Application Resource Management On-Prem_" and
   >   select the latest version.

--- a/labs/turbonomic/ui-and-k8s-data-target-lab/2-lab-environment/index.mdx
+++ b/labs/turbonomic/ui-and-k8s-data-target-lab/2-lab-environment/index.mdx
@@ -44,11 +44,11 @@ To complete this lab you will need:
   > IBM Business Partners can get a trial Turbonomic License from
   > [IBM Passport Advantage](https://www.ibm.com/software/passportadvantage/pao_download_software.html)
   >
-  > IBMers can follow the same instructions but use the internal downloads site
+  > IBMers can follow the same instructions but use the
+  > [internal downloads](https://w3.ibm.com/w3publisher/software-downloads) site
   >
-  > - Sign in to
-  >   [IBM Passport Advantage](https://www.ibm.com/software/passportadvantage/pao_download_software.html)
-  >   and select Software download
+  > - Sign in to the appropriate link as mentioned above and select Software
+  >   download
   >
   > - Search for "_IBM Turbonomic Application Resource Management On-Prem_" and
   >   select the latest version.


### PR DESCRIPTION
Seems not all internal folk know about the internal link, updated instructions to provide that information