### PR TITLE
Fix t8c-operator CRB indentation

### DIFF
--- a/labs/turbonomic/install-lab/3-installation/index.mdx
+++ b/labs/turbonomic/install-lab/3-installation/index.mdx
@@ -117,15 +117,15 @@ You are now ready to deploy the operator
    kind: ClusterRoleBinding
    apiVersion: rbac.authorization.k8s.io/v1
    metadata:
-   name: t8c-operator
+     name: t8c-operator
    subjects:
-   - kind: ServiceAccount
-   name: t8c-operator
-   namespace: turbonomic-platform
+     - kind: ServiceAccount
+       name: t8c-operator
+       namespace: turbonomic-platform
    roleRef:
-   kind: ClusterRole
-   name: t8c-operator
-   apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: t8c-operator
+     apiGroup: rbac.authorization.k8s.io
    EOF
    ```
 


### PR DESCRIPTION
The indentation was incorrect for direct copy and paste. 

The updated yaml has been tested in the lab. 

![image](https://github.com/IBM/waiops-tech-jam/assets/1493986/6097ba74-b96a-4437-b005-6553f4b11ec0)
