### PR TITLE
Use declarative namespace creation for robot-shop

### DIFF
--- a/labs/instana/applications-and-ibm-middleware/3-robot-shop-installation/index.mdx
+++ b/labs/instana/applications-and-ibm-middleware/3-robot-shop-installation/index.mdx
@@ -121,16 +121,21 @@ terminal window and trying again.
 cd ~ && git clone https://github.com/instana/robot-shop.git
 ```
 
-change directory into the **robot-shop/K8s** directory
+Change directory into the **robot-shop/K8s** directory
 
 ```sh
 cd robot-shop/K8s
 ```
 
-create namespace `robot-shop`:
+Ensure namespace `robot-shop` is created:
 
 ```sh
-oc create ns robot-shop --kubeconfig ~/kubeconfig-apps
+cat <<EOF | oc apply --server-side --kubeconfig ~/kubeconfig-apps -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: robot-shop
+EOF
 ```
 
 Next, setup **privileges** within the cluster for the **Robot Shop** application

--- a/labs/instana/applications-and-ibm-middleware/3-robot-shop-installation/index.mdx
+++ b/labs/instana/applications-and-ibm-middleware/3-robot-shop-installation/index.mdx
@@ -127,6 +127,12 @@ change directory into the **robot-shop/K8s** directory
 cd robot-shop/K8s
 ```
 
+create namespace `robot-shop`:
+
+```sh
+oc create ns robot-shop
+```
+
 Next, setup **privileges** within the cluster for the **Robot Shop** application
 by issuing the following two commands:
 

--- a/labs/instana/applications-and-ibm-middleware/3-robot-shop-installation/index.mdx
+++ b/labs/instana/applications-and-ibm-middleware/3-robot-shop-installation/index.mdx
@@ -130,7 +130,7 @@ cd robot-shop/K8s
 create namespace `robot-shop`:
 
 ```sh
-oc create ns robot-shop
+oc create ns robot-shop --kubeconfig ~/kubeconfig-apps
 ```
 
 Next, setup **privileges** within the cluster for the **Robot Shop** application


### PR DESCRIPTION
Avoid any warnings or errors where automation has created namespace in advance which may confuse novice users.