### PR TITLE
Adding a banner to the Netcool migration lab to say it is not ready

### DIFF
--- a/labs/cloud-pak-aiops/migration-from-netcool/1-introduction/index.mdx
+++ b/labs/cloud-pak-aiops/migration-from-netcool/1-introduction/index.mdx
@@ -6,6 +6,10 @@ description:
 sidebar_position: 1
 ---
 
+:::danger
+This lab is still under construction and is not yet available. This banner will be removed when it is ready for use.
+:::
+
 After a successful installation of the IBM Cloud Pak for AIOps, a common task will be to integrate an existing Netcool deployment into AIOps.
 
 AIOps will sit on top of an existing Netcool deployment, using Netcool/OMNIbus as an event source, and Netcool/Impact as an automation and integration engine. While some functions will be reimplemented in AIOps, many can remain in the Netcool layer, for example, event enrichment or ticketing integrations.


### PR DESCRIPTION
This small change adds a banner to the Netcool migration lab's introduction page to highlight that it is still under construction and not yet ready for use.