### PR TITLE
fixed AIOps lab overview page

### DIFF
--- a/labs/cloud-pak-aiops/introduction/index.mdx
+++ b/labs/cloud-pak-aiops/introduction/index.mdx
@@ -16,26 +16,24 @@ This is the Lab list:
   - Storage requirements
   - Integration with Lightweight Directory Access Protocol (LDAP)
 
-<!--
+- [**Topology**](../topology-lab/1-introduction/index.mdx)
+  - Collecting topology data
+  - Using rules to merge topology elements
+  - Using templates to gather resources into logical groups
+  - Define applications from groups and business criticality
+
+- [**Alert Correlation**](../alert-lab/1-introduction/index.mdx)
+  - Load sample event and alert data using a generic webhook and kafka topic
+  - Scope-based alert correlation
+  - Temporal alert correlation
+  - Topological alert correlation
 
 - [**Migration from Netcool**](../migration-from-netcool/1-introduction/index.mdx)
   - Set up an integration into Netcool/OMNIbus
   - Set up an integration into Netcool/Impact
   - Create an event housekeeping automation
   - Create a right-click tool that leverages Netcool/Impact
-
--->
-
-- [**Topology**](../topology-lab/1-introduction/index.mdx)
-  - Collecting topology data
-  - Using rules to merge topology elements
-  - Using templates to gather resources into logical groups
-  - Define applications from groups and business criticality
-- [**Alert Correlation**](../alert-lab/1-introduction/index.mdx)
-  - Load sample event and alert data using a generic webhook and kafka topic
-  - Scope-based alert correlation
-  - Temporal alert correlation
-  - Topological alert correlation
+  - Migrate custom correlation automation from Netcool
 
 More labs will be added in the future to explore more advanced scenarios and
 features of IBM Cloud Pak for AIOps.


### PR DESCRIPTION
I tweaked the AIOps lab intro page as it was missing the new Netcool migration information. I un-commented it and added a line about the newly added content relating to migration of custom correlation automation.