### PR TITLE
update instana key access information

### DIFF
--- a/labs/instana/administer-instana/2-lab-environment/index.mdx
+++ b/labs/instana/administer-instana/2-lab-environment/index.mdx
@@ -4,6 +4,8 @@ description: Instana lab environment setup
 sidebar_position: 2
 ---
 
+import LicenseInfo from "@site/src/components/Instana/LicenseInfo"
+
 # Lab Environment
 
 The lab environment includes 2 Openshift clusters and 3 VMs.
@@ -32,18 +34,7 @@ Virtual Machines:
 
 To complete this lab you will need:
 
-- **Instana License**
-
-  > IBM Business Partners can get a 2 week trial Instana License from
-  > [IBM PartnerWorld - Software Access Catalog](https://www.ibm.com/partnerworld/program/benefits/software-access-catalog)
-  > as part of the
-  > [IBM Partner Packages](https://www.ibm.com/partnerworld/public/partner-package).
-
-  > IBMers can get access to an Instana License
-  > [here](https://ibm.seismic.com/Link/Content/DCbhQJW3BgC2XGWMhVfVjMQV6gDB)
-
-  - Download/Agent Key (Required when requesting the lab environment)
-  - Sales Key (Required when requesting the lab environment)
+- <LicenseInfo />
 
 ## Requesting a Lab Environment
 

--- a/labs/instana/applications-and-ibm-middleware/2-lab-environment/index.mdx
+++ b/labs/instana/applications-and-ibm-middleware/2-lab-environment/index.mdx
@@ -4,6 +4,8 @@ description: Instana lab environment setup
 sidebar_position: 2
 ---
 
+import LicenseInfo from "@site/src/components/Instana/LicenseInfo"
+
 # Lab Environment
 
 The lab environment includes 2 Openshift clusters and 3 VMs.
@@ -33,18 +35,7 @@ Virtual Machines:
 
 To complete this lab you will need:
 
-- **Instana License**
-
-  > IBM Business Partners can get a 2 week trial Instana License from
-  > [IBM PartnerWorld - Software Access Catalog](https://www.ibm.com/partnerworld/program/benefits/software-access-catalog)
-  > as part of the
-  > [IBM Partner Packages](https://www.ibm.com/partnerworld/public/partner-package).
-
-  > IBMers can get access to an Instana License
-  > [here](https://ibm.seismic.com/Link/Content/DCbhQJW3BgC2XGWMhVfVjMQV6gDB)
-
-  - Download/Agent Key (Required when requesting the lab environment)
-  - Sales Key (Required when requesting the lab environment)
+- <LicenseInfo />
 
 ## Requesting a Lab Environment
 

--- a/labs/instana/explore-instana/2-lab-environment/index.mdx
+++ b/labs/instana/explore-instana/2-lab-environment/index.mdx
@@ -4,6 +4,8 @@ description: Instana lab environment setup
 sidebar_position: 2
 ---
 
+import LicenseInfo from "@site/src/components/Instana/LicenseInfo"
+
 # Lab Environment
 
 The lab environment includes 2 Openshift clusters and 3 VMs.
@@ -33,18 +35,7 @@ Virtual Machines:
 
 To complete this lab you will need:
 
-- **Instana License**
-
-  > IBM Business Partners can get a 2 week trial Instana License from
-  > [IBM PartnerWorld - Software Access Catalog](https://www.ibm.com/partnerworld/program/benefits/software-access-catalog)
-  > as part of the
-  > [IBM Partner Packages](https://www.ibm.com/partnerworld/public/partner-package).
-
-  > IBMers can get access to an Instana License
-  > [here](https://ibm.seismic.com/Link/Content/DCbhQJW3BgC2XGWMhVfVjMQV6gDB)
-
-  - Download/Agent Key (Required when requesting the lab environment)
-  - Sales Key (Required when requesting the lab environment)
+- <LicenseInfo />
 
 ## Requesting a Lab Environment
 

--- a/labs/instana/introduction/index.mdx
+++ b/labs/instana/introduction/index.mdx
@@ -4,6 +4,8 @@ description: Welcome to the Instana Jam-in-a-Box labs
 sidebar_position: 1
 ---
 
+import AdditionalResources from "@site/src/components/Instana/AdditionalResources"
+
 In the Instana labs of the AIOps Jam-in-a-Box series you will be going through
 several key exercises in order to learn more about Instana.
 
@@ -40,4 +42,4 @@ There are four Instana labs:
 More labs will be added in the future to explore more advanced scenarios and
 features of Instana.
 
----
+<AdditionalResources />

--- a/labs/instana/opentelemetry/2-lab-environment/index.mdx
+++ b/labs/instana/opentelemetry/2-lab-environment/index.mdx
@@ -4,6 +4,8 @@ description: Instana lab environment setup
 sidebar_position: 2
 ---
 
+import LicenseInfo from "@site/src/components/Instana/LicenseInfo"
+
 # Lab Environment
 
 :::warning Work In Progress
@@ -26,18 +28,7 @@ Openshift clusters:
 
 To complete this lab you will need:
 
-- **Instana License**
-
-  > IBM Business Partners can get a 2 week trial Instana License from
-  > [IBM PartnerWorld - Software Access Catalog](https://www.ibm.com/partnerworld/program/benefits/software-access-catalog)
-  > as part of the
-  > [IBM Partner Packages](https://www.ibm.com/partnerworld/public/partner-package).
-
-  > IBMers can get access to an Instana License
-  > [here](https://ibm.seismic.com/Link/Content/DCbhQJW3BgC2XGWMhVfVjMQV6gDB)
-
-  - Download/Agent Key (Required when requesting the lab environment)
-  - Sales Key (Required when requesting the lab environment)
+- <LicenseInfo />
 
 ## Requesting a Lab Environment
 

--- a/labs/instana/server-and-agent-install-lab/2-lab-environment/index.mdx
+++ b/labs/instana/server-and-agent-install-lab/2-lab-environment/index.mdx
@@ -4,6 +4,8 @@ description: Instana Sever & Agent Installation Environment Architecture
 sidebar_position: 2
 ---
 
+import LicenseInfo from "@site/src/components/Instana/LicenseInfo"
+
 # Lab Environment
 
 The lab environment includes 2 Openshift clusters and 3 VMs.
@@ -39,18 +41,7 @@ Virtual Machines:
 
 To complete this lab you will need:
 
-- **Instana License**
-
-  > IBM Business Partners can get a 2 week trial Instana License from
-  > [IBM PartnerWorld - Software Access Catalog](https://www.ibm.com/partnerworld/program/benefits/software-access-catalog)
-  > as part of the
-  > [IBM Partner Packages](https://www.ibm.com/partnerworld/public/partner-package).
-
-  > IBMers can get access to an Instana License
-  > [here](https://ibm.seismic.com/Link/Content/DCbhQJW3BgC2XGWMhVfVjMQV6gDB)
-
-  - Download/Agent Key (Entered during the lab)
-  - Sales Key (Entered during the lab)
+- <LicenseInfo requiredWhen="during lab" />
 
 ## Requesting a Lab Environment
 

--- a/labs/instana/synthetic-pop/2-lab-environment/index.mdx
+++ b/labs/instana/synthetic-pop/2-lab-environment/index.mdx
@@ -4,6 +4,8 @@ description: Instana lab environment setup
 sidebar_position: 2
 ---
 
+import LicenseInfo from "@site/src/components/Instana/LicenseInfo"
+
 # Lab Environment
 
 :::warning Work In Progress
@@ -27,18 +29,7 @@ Openshift clusters:
 
 To complete this lab you will need:
 
-- **Instana License**
-
-  > IBM Business Partners can get a 2 week trial Instana License from
-  > [IBM PartnerWorld - Software Access Catalog](https://www.ibm.com/partnerworld/program/benefits/software-access-catalog)
-  > as part of the
-  > [IBM Partner Packages](https://www.ibm.com/partnerworld/public/partner-package).
-
-  > IBMers can get access to an Instana License
-  > [here](https://ibm.seismic.com/Link/Content/DCbhQJW3BgC2XGWMhVfVjMQV6gDB)
-
-  - Download/Agent Key (Required when requesting the lab environment)
-  - Sales Key (Required when requesting the lab environment)
+- <LicenseInfo />
 
 ## Requesting a Lab Environment
 

--- a/src/components/Instana/AdditionalResources.tsx
+++ b/src/components/Instana/AdditionalResources.tsx
@@ -1,0 +1,49 @@
+import React from "react"
+
+const communityPages =
+  "https://community.ibm.com/community/user/blogs/ciaran-darcy/2024/05/23/instana-essentials-series?CommunityKey=8d661410-d1fb-4067-ab9a-019475fc541e"
+
+const accessEnablementDeck =
+  "https://ibm.seismic.com/Link/Content/DCQfMjDgqWT2B87FWXPhGXQbJGDP"
+
+/**
+ * Reusable license information for Instana labs.
+ */
+export default function AdditionalResources() {
+  return (
+    <div>
+      <h2>Additional Enablement Resources</h2>
+      <ul>
+        <li>
+          <a
+            href={accessEnablementDeck}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Partner access and enablement presentation
+          </a>{" "}
+          containing:
+          <ul>
+            <li>Demo and Sandbox environments</li>
+            <li>
+              Instana 8-part technical essentials series
+              <ul>
+                <li>
+                  A good set of prerequisite overviews for Jam-in-a-Box hands-on
+                  labs.
+                </li>
+              </ul>
+            </li>
+            <li>License keys for these labs and self-enablement.</li>
+            <li>And more...</li>
+          </ul>
+        </li>
+        <li>
+          <a href={communityPages} target="_blank" rel="noopener noreferrer">
+            Community blogs and forums
+          </a>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/src/components/Instana/AdditionalResources.tsx
+++ b/src/components/Instana/AdditionalResources.tsx
@@ -24,7 +24,7 @@ export default function AdditionalResources() {
           </a>{" "}
           containing:
           <ul>
-            <li>Demo and Sandbox environments</li>
+            <li>Demo and Sandbox environments.</li>
             <li>
               Instana 8-part technical essentials series:
               <ul>
@@ -40,7 +40,7 @@ export default function AdditionalResources() {
         </li>
         <li>
           <a href={communityPages} target="_blank" rel="noopener noreferrer">
-            Community blogs and forums
+            Community blogs and forums.
           </a>
         </li>
       </ul>

--- a/src/components/Instana/AdditionalResources.tsx
+++ b/src/components/Instana/AdditionalResources.tsx
@@ -26,7 +26,7 @@ export default function AdditionalResources() {
           <ul>
             <li>Demo and Sandbox environments</li>
             <li>
-              Instana 8-part technical essentials series
+              Instana 8-part technical essentials series:
               <ul>
                 <li>
                   A good set of prerequisite overviews for Jam-in-a-Box hands-on

--- a/src/components/Instana/LicenseInfo.tsx
+++ b/src/components/Instana/LicenseInfo.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+
+const licenseInfoLink =
+  "https://ibm.seismic.com/Link/Content/DCQfMjDgqWT2B87FWXPhGXQbJGDP"
+
+/**
+ * Reusable license information for Instana labs.
+ */
+export default function InstanaLicenseInfo({
+  requiredWhen = "when requesting the lab environment",
+}) {
+  return (
+    <div>
+      <strong>Instana license keys (Required {requiredWhen}):</strong>
+      <ul>
+        <li>Agent / Download Key</li>
+        <li>Sales Key</li>
+      </ul>
+      <br />
+      <blockquote>
+        <p>
+          IBMers and IBM Business Partners can get license keys from the{" "}
+          <a href={licenseInfoLink} target="_blank" rel="noopener noreferrer">
+            Partner Access to Instana
+          </a>{" "}
+          presentation.
+          <br />
+          <strong>
+            Note: Keys are rotated every 6 months so please check at time of
+            requesting lab.
+          </strong>
+        </p>
+      </blockquote>
+    </div>
+  )
+}


### PR DESCRIPTION
Updates the access key information for Instana labs after changes to upstream source link in Seismic.
Also added additional resources, such as community blogs info as well as demo / sandbox information working with the enablement team.

- Additional resources on `Labs Overview` page:
  ![image](https://github.com/user-attachments/assets/23c5ddcc-2f2b-4ede-9ac1-039c60b86079)

- Key access information revamped into a data-driven component for reuse:
  - Install labs where students need keys during lab:
    ![image](https://github.com/user-attachments/assets/31b8270b-35bc-497d-b340-61cead04c98c)
  - Other labs where students need keys to request environments:    
    ![image](https://github.com/user-attachments/assets/8666833b-b538-4381-8030-7ef025eb2aa3)

