### PR TITLE
upload-artifact@v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,9 +59,11 @@ jobs:
           steps.detect-package-manager.outputs.command }}
       - name: Build website
         run: ${{ steps.detect-package-manager.outputs.manager }} run build
+
       - name: Upload artifact
         # https://github.com/actions/upload-pages-artifact/blob/main/action.yml
-        uses: actions/upload-pages-artifact@v1
+        id: upload-artifact
+        uses: actions/upload-artifact@v4
         with:
           # Docusaurus build path
           path: ./build


### PR DESCRIPTION
Build are failing. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

```
Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact).
```

PR to update upload-artifact to v4