### PR TITLE
use upload-pages-artifact action for site build flow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Upload artifact
         # https://github.com/actions/upload-pages-artifact/blob/main/action.yml
         id: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           # Docusaurus build path
           path: ./build
@@ -78,4 +78,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Build's still failing at the deploy stage, unable to find artifact. 

Looking at the difference between `upload-artifact` and `upload-pages-artifact` seems we need to use `actions/upload-pages-artifact@v3` instead when using `actions/deploy-pages`.
I also bumped `deploy-pages` to `@v4` latest.

Hopefully this fixes the deploy stage.