### PR TITLE
fix SBEG policy config tag

### DIFF
--- a/labs/cloud-pak-aiops/alert-lab/5-scope-based/index.mdx
+++ b/labs/cloud-pak-aiops/alert-lab/5-scope-based/index.mdx
@@ -86,8 +86,8 @@ Now we will create a new scope-based policy:
     - For **Property** select **alert.resource.location**
     - For **Operator** select **contains**
     - For **Matches** select **any of**
-    - For **Value** type (use uppercase in both) US-SOUTH and select String:
-      US-South, type US-EAST and select String: US-EAST
+    - For **Value** type (use uppercase in both) US-SOUTH and select
+      `String: US-SOUTH`, type US-EAST and select `String: US-EAST`
   - Under **Create a scope-based grouping**:
 
     - select **resource.location**


### PR DESCRIPTION
Typo in lab instructions using Camel-cased US-SOUTH tag value. 
Should be all uppercase.