### PR TITLE
deprecate and disable turbonomic labs ready for removal

### DIFF
--- a/labs/turbonomic/_category_.json
+++ b/labs/turbonomic/_category_.json
@@ -1,4 +1,5 @@
 {
   "label": "Turbonomic Labs",
-  "position": 30
+  "position": 30,
+  "className": "wip-docs"
 }


### PR DESCRIPTION
Disabled the turbonomic labs from site as we no longer support it. 