### PR TITLE
correct k3's to K3s in lab material

### DIFF
--- a/labs/instana/administer-instana/2-lab-environment/index.mdx
+++ b/labs/instana/administer-instana/2-lab-environment/index.mdx
@@ -10,13 +10,15 @@ import LicenseInfo from "@site/src/components/Instana/LicenseInfo"
 
 The lab environment includes 6 VMs.
 
-1. **Bastion VM** - A RHEL VM named `bastion-gym-lan` that will be used as the _bastion host_ for the
-   lab network. This Bastion host has access to all lab VM's and will be
-   your primary workstation for these labs.
-2. **Instana VMs** - 3 Ubuntu VMs that are running a multi-node self-hosted Instana server on K3's.
-3. **MQACE** - An Ubuntu VM that contains pre-installed Instana Agent, IBM ACE and MQ
-   middleware.
-4. **Demo Applications Cluster** - An Ubuntu VM running K3s, it has the Instana Agent, Quote of the Day and Robot Shop demo applications running.
+1. **Bastion VM** - A RHEL VM named `bastion-gym-lan` that will be used as the
+   _bastion host_ for the lab network. This Bastion host has access to all lab
+   VM's and will be your primary workstation for these labs.
+2. **Instana VMs** - 3 Ubuntu VMs that are running a multi-node self-hosted
+   Instana server on K3s.
+3. **MQACE** - An Ubuntu VM that contains pre-installed Instana Agent, IBM ACE
+   and MQ middleware.
+4. **Demo Applications Cluster** - An Ubuntu VM running K3s, it has the Instana
+   Agent, Quote of the Day and Robot Shop demo applications running.
 
 ![architecture](images/architecture.png)
 

--- a/labs/instana/applications-and-ibm-middleware/2-lab-environment/index.mdx
+++ b/labs/instana/applications-and-ibm-middleware/2-lab-environment/index.mdx
@@ -10,13 +10,16 @@ import LicenseInfo from "@site/src/components/Instana/LicenseInfo"
 
 The lab environment includes 6 VMs.
 
-1. **Bastion VM** - A RHEL VM named `bastion-gym-lan` that will be used as the _bastion host_ for the
-   lab network. This Bastion host has access to all lab VM's and will be
-   your primary workstation for these labs.
-2. **Instana VMs** - 3 Ubuntu VMs that are running a multi-node self-hosted Instana server on K3's.
+1. **Bastion VM** - A RHEL VM named `bastion-gym-lan` that will be used as the
+   _bastion host_ for the lab network. This Bastion host has access to all lab
+   VM's and will be your primary workstation for these labs.
+2. **Instana VMs** - 3 Ubuntu VMs that are running a multi-node self-hosted
+   Instana server on K3s.
 3. **MQACE** - An Ubuntu VM that contains the pre-installed IBM ACE and MQ
    middleware.
-4. **Demo Applications Cluster** - An Ubuntu VM running K3s, it has the Instana Agent and Quote of the Day demo application running. It will be used to install the Robot Shop demo application in this lab.
+4. **Demo Applications Cluster** - An Ubuntu VM running K3s, it has the Instana
+   Agent and Quote of the Day demo application running. It will be used to
+   install the Robot Shop demo application in this lab.
 
 ![architecture](images/architecture.png)
 

--- a/labs/instana/explore-instana/2-lab-environment/index.mdx
+++ b/labs/instana/explore-instana/2-lab-environment/index.mdx
@@ -10,14 +10,15 @@ import LicenseInfo from "@site/src/components/Instana/LicenseInfo"
 
 The lab environment includes 6 VMs.
 
-1. **Bastion VM** - A RHEL VM named `bastion-gym-lan` that will be used as the _bastion host_ for the
-   lab network. This Bastion host has access to all lab VM's and will be
-   your primary workstation for these labs.
-2. **Instana VMs** - 3 Ubuntu VMs that are running a multi-node self-hosted Instana server on K3's.
+1. **Bastion VM** - A RHEL VM named `bastion-gym-lan` that will be used as the
+   _bastion host_ for the lab network. This Bastion host has access to all lab
+   VM's and will be your primary workstation for these labs.
+2. **Instana VMs** - 3 Ubuntu VMs that are running a multi-node self-hosted
+   Instana server on K3s.
 3. **MQACE** - An Ubuntu VM that contains the pre-installed IBM ACE and MQ
    middleware.
-4. **Demo Applications Cluster** - An Ubuntu VM running K3s, it has the Instana Agent, Robot Shop and Quote of the Day demo applications running.
-
+4. **Demo Applications Cluster** - An Ubuntu VM running K3s, it has the Instana
+   Agent, Robot Shop and Quote of the Day demo applications running.
 
 ![architecture](images/architecture.png)
 

--- a/labs/instana/server-and-agent-install-lab/1-introduction/index.mdx
+++ b/labs/instana/server-and-agent-install-lab/1-introduction/index.mdx
@@ -11,10 +11,11 @@ several key exercises that will help you learn more about the installation and
 configuration of the Instana Server and Instana Agent. You will cover topics
 such as:
 
-- The installation process for a self-hosted, multi-node K3's based Instana.
+- The installation process for a self-hosted, multi-node K3s based Instana.
 - Licensing the Instana Server.
 - Configuring SMTP for the Instana Server.
-- Installing the Instana Agent into a variety of environments (locally with the Instana Server, Kubernetes and Linux).
+- Installing the Instana Agent into a variety of environments (locally with the
+  Instana Server, Kubernetes and Linux).
 - Troubleshooting steps you can take if the Agent doesn't appear to be
   connecting to the Server correctly.
 

--- a/labs/instana/server-and-agent-install-lab/2-lab-environment/index.mdx
+++ b/labs/instana/server-and-agent-install-lab/2-lab-environment/index.mdx
@@ -10,14 +10,16 @@ import LicenseInfo from "@site/src/components/Instana/LicenseInfo"
 
 The lab environment includes 6 VMs.
 
-1. **Bastion VM** - A RHEL VM named `bastion-gym-lan` that will be used as the _bastion host_ for the
-   lab network. This Bastion host has access to all lab VM's and will be
-   your primary workstation for these labs.
-2. **Instana VMs** - 3 Ubuntu VMs that will be used to install a multi-node self-hosted Instana server on K3's.
+1. **Bastion VM** - A RHEL VM named `bastion-gym-lan` that will be used as the
+   _bastion host_ for the lab network. This Bastion host has access to all lab
+   VM's and will be your primary workstation for these labs.
+2. **Instana VMs** - 3 Ubuntu VMs that will be used to install a multi-node
+   self-hosted Instana server on K3s.
 3. **MQACE** - An Ubuntu VM that contains the pre-installed IBM ACE and MQ
    middleware. This VM will be used to install the Instana agent and monitor the
    middleware.
-4. **Demo Applications Cluster** - An Ubuntu VM running K3s that will be used to install the Instana agent and demo applications.
+4. **Demo Applications Cluster** - An Ubuntu VM running K3s that will be used to
+   install the Instana agent and demo applications.
 
 ![architecture](images/architecture-instana.png)
 

--- a/labs/instana/server-and-agent-install-lab/99-quiz/index.mdx
+++ b/labs/instana/server-and-agent-install-lab/99-quiz/index.mdx
@@ -17,7 +17,12 @@ import MultiChoiceQuestion from "../../../_common/components/multi-choice.jsx"
 <MultiChoiceQuestion
   questionNumber="1"
   question="Which of the following is not an Instana on-premises deployment option?"
-  answers={["Custom Edition", "Standard Edition (K3S)", "Instana Appliance", "Classic Edition (Docker)"]}
+  answers={[
+    "Custom Edition",
+    "Standard Edition (K3s)",
+    "Instana Appliance",
+    "Classic Edition (Docker)",
+  ]}
   correctAnswer="Instana Appliance"
 />
 
@@ -35,7 +40,7 @@ import MultiChoiceQuestion from "../../../_common/components/multi-choice.jsx"
     "Updating the **configuration.yaml** file",
     "Updating the **settings.hcl** file",
     "Specify the --core-feature-flags flag with **stanctl backend apply**",
-    "Editing the **instana configmap**"
+    "Editing the **instana configmap**",
   ]}
   correctAnswer="Specify the --core-feature-flags flag with **stanctl backend apply**"
 />


### PR DESCRIPTION
Incorrectly names **k3's** renamed to **K3s** in lab environment pages and a few other places.