### PR TITLE
concert formatting sh code block

### DIFF
--- a/labs/concert/op-certificate-mgmt/3-lab-preparation/index.mdx
+++ b/labs/concert/op-certificate-mgmt/3-lab-preparation/index.mdx
@@ -28,7 +28,7 @@ This is for information only. Later in this page you will be instructed to run t
 
 Note that from the Bastion SSH, you can ssh into each other VM with the commands below: 
 
-```bash
+```bash title="Host: bastion-gym-lan"
 # Access the Concert VM
 ssh jammer@concert
 # Access the CFSSL VM
@@ -81,7 +81,7 @@ Private Key value for "jammer" user on bluebox VM (copy the value BELOW this lin
 
 From the Bastion SSH, run the command below:
 
-```bash
+```sh title="Host: bastion-gym-lan"
 cat demo-details.yml | grep -E 'concert'
 ``` 
 
@@ -124,19 +124,19 @@ DO NOT use these watsonx.ai credentials for any other purpose outside this lab.
 From the Bastion SSH, run the following command to login to the Concert host with the user 'jammer'. If this is your first time connecting, 
 you may need to accept the host key fingerprint.
 
-```bash
+```sh title="Host: bastion-gym-lan"
 ssh jammer@concert
 ```
 Once logged in, run the following command:
 
-```bash
+```sh title="Host: concert"
 export INSTALL_DIR=/opt/ibm/concert/ibm-concert
 ```
 
 Obtain the required credentials for connecting to watsonx.ai. Open [**this Box Note**](https://ibm.box.com/v/concert-vuln-lab), 
-copy the three lines and run them in the Concert host Terminal to set the environment variables. 
+copy the four lines and run them in the Concert host Terminal to set the environment variables. 
 
-```bash
+```bash title="Host: concert"
 # use the exports from the Box Note, they should look similar to this:
 export WATSONX_API_MODEL_ID=
 export WATSONX_API_KEY=... 
@@ -146,7 +146,7 @@ export WATSONX_API_URL=...
 
 Just to confirm the four env. variables are set, run this command and make sure each line shows a value:
 
-```bash
+```bash title="Host: concert"
 echo "INSTALL_DIR=$INSTALL_DIR"
 echo "WATSONX_API_MODEL_ID=$WATSONX_API_MODEL_ID"
 echo "WATSONX_API_KEY=$WATSONX_API_KEY"
@@ -156,7 +156,7 @@ echo "WATSONX_API_URL=$WATSONX_API_URL"
 
 Run the commands below to apply the watsonx.ai configuration into the file **local_config.env**:
 
-```bash
+```bash title="Host: concert"
 echo "WATSONX_API_MODEL_ID=$WATSONX_API_MODEL_ID" >> $INSTALL_DIR/ibm-concert-std/etc/local_config.env
 echo "WATSONX_API_KEY=$WATSONX_API_KEY" >> $INSTALL_DIR/ibm-concert-std/etc/local_config.env
 echo "WATSONX_API_PROJECT_ID=$WATSONX_API_PROJECT_ID" >> $INSTALL_DIR/ibm-concert-std/etc/local_config.env
@@ -169,7 +169,7 @@ Finally, run the two commands below **one by one** to restart the py-utils servi
 In the last **start_service** command, you can ignore one or more warnings **WARN[0000] Failed to mount subscriptions ...**
 :::
 
-```bash
+```bash title="Host: concert"
 $INSTALL_DIR/ibm-concert-std/bin/stop_service ibm-roja-py-utils
 $INSTALL_DIR/ibm-concert-std/bin/start_service ibm-roja-py-utils
 ```

--- a/labs/concert/op-certificate-mgmt/4-workflows-preparation/index.mdx
+++ b/labs/concert/op-certificate-mgmt/4-workflows-preparation/index.mdx
@@ -36,11 +36,11 @@ to run Workflows.
 
 From the Terminal window, use the **ping** command to capture demo-apps VM IP Address. Save the value after **demo-apps IP address** in the credentials file.
 
-```sh
+```sh title="Host: bastion-gym-lan"
 ping demo-apps.ibmdte.local
 ```
 
-```sh
+```sh title="Example Output"
 PING demo-apps.ibmdte.local (192.168.252.33) 56(84) bytes of data.
 64 bytes from demo-apps.ibmdte.local (192.168.252.33): icmp_seq=1 ttl=64 time=0.063 ms
 64 bytes from demo-apps.ibmdte.local (192.168.252.33): icmp_seq=2 ttl=64 time=0.101 ms
@@ -52,7 +52,7 @@ Now let's capture Private Key value for **jammer** user on **demo-apps** VM whic
 
 Use the terminal to login to the **demo-apps** host:
 
-```sh
+```sh title="Host: bastion-gym-lan"
 ssh jammer@demo-apps
 ```
 
@@ -61,11 +61,11 @@ When prompted if you want to continue connecting, type: `yes`
 Use **cat** command to print Private Key file content. Copy the file content into the credentials file under **Private Key value for "jammer" user on demo-apps VM**.
 Make sure to save the credentials file. 
 
-```sh
+```sh title="Host: demo-apps"
 cat $HOME/.ssh/id_rsa
 ```
 
-```sh
+```sh title="Example Output"
 -----BEGIN OPENSSH PRIVATE KEY-----
 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAACFwAAAAdzc2gtcn
 ...intentionally truncated...
@@ -90,7 +90,7 @@ Now that you have the Private Key value for **jammer** user and **demo-apps VM i
   only one server which is the demo-apps VM
 
 
-```sh
+```sh title="Example Input"
 [canary]
 192.168.252.33 ansible_host=demo-apps.ibmdte.local ansible_user=jammer ansible_password=Passw0rd
 ```
@@ -138,11 +138,11 @@ Before you create the new Authentication, let's capture the bluebox VM IP addres
 
 Use the **ping** command to capture bluebox VM ip address. Save the ip address from **ping** output into the credentials file.
 
-```sh
+```sh title="Host: bastion-gym-lan"
 ping bluebox.ibmdte.local
 ```
 
-```sh
+```sh title="Example Output"
 PING bluebox.ibmdte.local (192.168.252.35) 56(84) bytes of data.
 64 bytes from bluebox.ibmdte.local (192.168.252.35): icmp_seq=1 ttl=64 time=0.044 ms
 64 bytes from bluebox.ibmdte.local (192.168.252.35): icmp_seq=2 ttl=64 time=0.105 ms
@@ -153,7 +153,7 @@ PING bluebox.ibmdte.local (192.168.252.35) 56(84) bytes of data.
 
 Now we wil capture the Private Key. Use the terminal to login to **bluebox** host:
 
-```sh
+```sh title="Host: bastion-gym-lan"
 ssh jammer@bluebox
 ```
 
@@ -162,11 +162,11 @@ When prompted if you want to continue connecting, type: `yes`
 Use the **cat** command to print the Private Key file content. Copy the file content into the credentials file under **Private Key value for "jammer" user on bluebox VM**.
 Make sure to save the credentials file. 
 
-```sh
+```sh title="Host: bluebox"
 cat $HOME/.ssh/id_rsa
 ```
 
-```sh
+```sh title="Example Output"
 -----BEGIN OPENSSH PRIVATE KEY-----
 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAACFwAAAAdzc2gtcn
 ...intentionally truncated...
@@ -188,7 +188,7 @@ Now that you have the Private Key value for **jammer** user on **bluebox**, you 
   should include `-----BEGIN OPENSSH PRIVATE KEY -----` and `-----END OPENSSH PRIVATE KEY-----` as part of the value.
   * **Inventory**: enter Ansible Inventory as shown below
 
-```sh
+```sh title="Example Input"
 [canary]
 192.168.252.35 ansible_host=bluebox.ibmdte.local ansible_user=jammer ansible_password=Passw0rd
 ```
@@ -265,7 +265,7 @@ the location of the server.jks file. Later, we will use this authentication to r
 * Under **Property** section, provide the following details:
   * **Data**: enter JSON payload below
 
-```sh
+```sh title="Example Input"
 {
   "/opt/tomcat/ssl/server.jks" : "tomcat"
 }

--- a/labs/concert/op-certificate-mgmt/4-workflows-preparation/index.mdx
+++ b/labs/concert/op-certificate-mgmt/4-workflows-preparation/index.mdx
@@ -90,7 +90,7 @@ Now that you have the Private Key value for **jammer** user and **demo-apps VM i
   only one server which is the demo-apps VM
 
 
-```sh title="Example Input"
+```sh title="As Is"
 [canary]
 192.168.252.33 ansible_host=demo-apps.ibmdte.local ansible_user=jammer ansible_password=Passw0rd
 ```

--- a/labs/concert/op-certificate-mgmt/4-workflows-preparation/index.mdx
+++ b/labs/concert/op-certificate-mgmt/4-workflows-preparation/index.mdx
@@ -188,7 +188,7 @@ Now that you have the Private Key value for **jammer** user on **bluebox**, you 
   should include `-----BEGIN OPENSSH PRIVATE KEY -----` and `-----END OPENSSH PRIVATE KEY-----` as part of the value.
   * **Inventory**: enter Ansible Inventory as shown below
 
-```sh title="Example Input"
+```sh title="As Is"
 [canary]
 192.168.252.35 ansible_host=bluebox.ibmdte.local ansible_user=jammer ansible_password=Passw0rd
 ```
@@ -265,7 +265,7 @@ the location of the server.jks file. Later, we will use this authentication to r
 * Under **Property** section, provide the following details:
   * **Data**: enter JSON payload below
 
-```sh title="Example Input"
+```sh title="As Is"
 {
   "/opt/tomcat/ssl/server.jks" : "tomcat"
 }

--- a/labs/concert/op-certificate-mgmt/5-certificate-discovery-javaKeyStore/index.mdx
+++ b/labs/concert/op-certificate-mgmt/5-certificate-discovery-javaKeyStore/index.mdx
@@ -128,13 +128,13 @@ The trust chain hierarchy for the certificates stored in the keystore file is as
 
 From the Bastion SSH, connect to **demo-apps**:
 
-```sh
+```sh title="Host: bastion-gym-lan"
 ssh jammer@demo-apps
 ```
 
 Run the following to list all Certificates in Apache Tomcat Java Keystore:
 
-```sh  title="Host: demo-apps"
+```sh title="Host: demo-apps"
 sudo keytool -list -v -keystore /opt/tomcat/ssl/server.jks -storepass tomcat
 ```
 
@@ -322,7 +322,7 @@ From the Bastion SSH, run the **curl** command, after replacing the following **
   - Replace the value after **search=** with the actual Certificate Serial Number obtained from your Concert Certificate UI
   - Replace the value after **C_API_KEY:** with your Concert API Key.
 
-```sh
+```sh title="Host: bastion-gym-lan"
 curl -sk \
   --request GET https://concert.ibmdte.local:12443/core/api/v1/certificates?search=<CERTIFICATE_SERIAL_NUMBER> \
   --header 'Authorization: C_API_KEY: <YOUR_CONCERT_API_KEY>' \
@@ -333,7 +333,7 @@ curl -sk \
 
 This is an example of the expected output:
 
-```sh
+```sh title="Example Output"
 {
   "pagination": {
     "total_count": 1,

--- a/labs/concert/op-certificate-mgmt/6-certificate-renewal-javaKeyStore/index.mdx
+++ b/labs/concert/op-certificate-mgmt/6-certificate-renewal-javaKeyStore/index.mdx
@@ -244,7 +244,7 @@ From the Bastion SSH, run the **curl** command, after replacing the following **
   - Replace the value after **search=** with the actual Certificate Serial Number obtained from your Concert Certificate UI
   - Replace the value after **C_API_KEY:** with your Concert API Key.
 
-```sh
+```sh title="Host: bastion-gym-lan"
 curl -sk \
   --request GET https://concert.ibmdte.local:12443/core/api/v1/certificates?search=<CERTIFICATE_SERIAL_NUMBER> \
   --header 'Authorization: C_API_KEY: <YOUR_CONCERT_API_KEY>' \
@@ -255,7 +255,7 @@ curl -sk \
 
 This is an example of the expected output:
 
-```sh
+```sh title="Example Output"
 {
   "pagination": {
     "total_count": 1,
@@ -305,13 +305,13 @@ Let's use Java Keytool command to verify the Apache Tomcat certificate in Java K
 
 From the Bastion SSH, connect to **demo-apps**:
 
-```sh
+```sh title="Host: bastion-gym-lan"
 ssh jammer@demo-apps
 ```
 
 Run the following to list all Certificates in Apache Tomcat Java Keystore:
 
-```sh
+```sh title="Host: demo-apps"
 sudo keytool -list -v -keystore /opt/tomcat/ssl/server.jks -storepass tomcat
 ```
 
@@ -330,7 +330,7 @@ Be aware that the certificate serial number in your lab environment may differ f
 
 Example keytool command output:
 
-```sh
+```sh title="Example Output"
 Keystore type: JKS
 Keystore provider: SUN
 

--- a/labs/concert/os-patch-management/3-lab-preparation/index.mdx
+++ b/labs/concert/os-patch-management/3-lab-preparation/index.mdx
@@ -37,7 +37,7 @@ Then click on the bookmark **Concert** to launch the Concert UI.
 
 You can connect from the Bastion host to other lab VMs using SSH commands as shown below.
 
-```bash
+```bash title="Host: bastion-gym-lan"
 # Access the Concert VM
 ssh jammer@concert
 
@@ -92,7 +92,7 @@ rhel_vm_private_key: <paste the private key under this line, including the BEGIN
 Next, run the following command from the **Bastion SSH terminal** to capture the IP address of the demo application:
 
 
-```bash
+```bash title="Host: bastion-gym-lan"
 getent hosts demo-apps | awk '{print $1}'
 ```
 
@@ -120,12 +120,12 @@ The demo-apps VM uses SSH key-based authentication. There is a pre-generated SSH
 and you will need to retrieve the private key so we can use it later in the lab to enable Concert to connect to this VM.
 
 Run the following command to connect from the Bastion host to the demo-apps VM:
-```bash
+```bash title="Host: bastion-gym-lan"
 ssh jammer@demo-apps
 ```
 
 After connecting, display the private key by running:
-```bash
+```bash title="Host: demo-apps"
 cat ~/.ssh/id_rsa
 ```
 
@@ -138,7 +138,7 @@ rhel_vm_private_key:
 ```
 Make sure to exit the ssh session to the demo-apps VM by running the `exit` command in the terminal.
 
-```bash
+```bash title="Host: demo-apps"
 exit
 ```
 
@@ -199,19 +199,19 @@ DO NOT use these watsonx.ai credentials for any other purpose outside this lab.
 From the Bastion SSH, run the following command to login to the Concert host with the user 'jammer'. If this is your first time connecting, 
 you may need to accept the host key fingerprint.
 
-```bash
+```bash title="Host: bastion-gym-lan"
 ssh jammer@concert
 ```
 Once logged in, run the following command:
 
-```bash
+```bash title="Host: concert"
 export INSTALL_DIR=/opt/ibm/concert/ibm-concert
 ```
 
 Obtain the required credentials for connecting to watsonx.ai. Open [**this Box Note**](https://ibm.box.com/v/concert-vuln-lab), 
-copy the three lines and run them in the Concert host Terminal to set the environment variables. 
+copy the four lines and run them in the Concert host Terminal to set the environment variables. 
 
-```bash
+```bash title="Host: concert"
 # use the exports from the Box Note, they should look similar to this:
 export WATSONX_API_MODEL_ID=
 export WATSONX_API_KEY=... 
@@ -221,7 +221,7 @@ export WATSONX_API_URL=...
 
 Just to confirm the four env. variables are set, run this command and make sure each line shows a value:
 
-```bash
+```bash title="Host: concert"
 echo "INSTALL_DIR=$INSTALL_DIR"
 echo "WATSONX_API_MODEL_ID=$WATSONX_API_MODEL_ID"
 echo "WATSONX_API_KEY=$WATSONX_API_KEY"
@@ -231,7 +231,7 @@ echo "WATSONX_API_URL=$WATSONX_API_URL"
 
 Run the commands below to apply the watsonx.ai configuration into the file **local_config.env**:
 
-```bash
+```bash title="Host: concert"
 echo "WATSONX_API_MODEL_ID=$WATSONX_API_MODEL_ID" >> $INSTALL_DIR/ibm-concert-std/etc/local_config.env
 echo "WATSONX_API_KEY=$WATSONX_API_KEY" >> $INSTALL_DIR/ibm-concert-std/etc/local_config.env
 echo "WATSONX_API_PROJECT_ID=$WATSONX_API_PROJECT_ID" >> $INSTALL_DIR/ibm-concert-std/etc/local_config.env
@@ -244,7 +244,7 @@ Finally, run the two commands below **one by one** to restart the py-utils servi
 In the last **start_service** command, you can ignore one or more warnings **WARN[0000] Failed to mount subscriptions ...**
 :::
 
-```bash
+```bash title="Host: concert"
 $INSTALL_DIR/ibm-concert-std/bin/stop_service ibm-roja-py-utils
 $INSTALL_DIR/ibm-concert-std/bin/start_service ibm-roja-py-utils
 ```
@@ -258,9 +258,12 @@ patch management capabilities of Concert in later sections of the lab. This open
 trigger [RHSA-2025:7586](https://access.redhat.com/errata/RHSA-2025:7586). 
 
 Run these commands one by one: 
-```bash
+```bash title="Host: bastion-gym-lan"
 # connect to the demo-apps VM from the Bastion host using SSH 
 ssh jammer@demo-apps
+```
+
+```bash title="Host: demo-apps"
 # downgrade the current version of ghostscript installed.
 # You may get a message that the version is already the same as the one we are downgrading to (nothing to do)
 sudo dnf downgrade -y ghostscript-9.54.0-14.el9_3.x86_64

--- a/labs/concert/os-patch-management/5-vuln-patch/index.mdx
+++ b/labs/concert/os-patch-management/5-vuln-patch/index.mdx
@@ -33,7 +33,7 @@ We will do this from **Concert Workflows** → **Authentications** tab.
    - **Service**: **Config Data**
    - **Data** (in JSON format):
 
-```json title="Example Input"
+```json title="As Is"
 {
   "host": "concert.ibmdte.local",
   "port": "12443",
@@ -83,7 +83,7 @@ We will do this from **Concert Workflows** → **Authentications** tab.
 
    - **Inventory**: Enter the following content. This follows the Ansible hosts format:
 
-     ```ini title="Example Input"
+     ```ini title="As Is"
      [canary]
      192.168.252.33 ansible_user=jammer ansible_ssh_common_args='-o StrictHostKeyChecking=no'
      ```
@@ -103,7 +103,7 @@ We will do this from **Concert Workflows** → **Authentications** tab.
    - **Service**: **Config Data**
    - **Data (required)**: Enter the following JSON:
 
-      ```json title="Example Input"
+      ```json title="As Is"
       {
         "config": [
           {

--- a/labs/concert/os-patch-management/5-vuln-patch/index.mdx
+++ b/labs/concert/os-patch-management/5-vuln-patch/index.mdx
@@ -33,7 +33,7 @@ We will do this from **Concert Workflows** → **Authentications** tab.
    - **Service**: **Config Data**
    - **Data** (in JSON format):
 
-```json
+```json title="Example Input"
 {
   "host": "concert.ibmdte.local",
   "port": "12443",
@@ -83,7 +83,7 @@ We will do this from **Concert Workflows** → **Authentications** tab.
 
    - **Inventory**: Enter the following content. This follows the Ansible hosts format:
 
-     ```ini
+     ```ini title="Example Input"
      [canary]
      192.168.252.33 ansible_user=jammer ansible_ssh_common_args='-o StrictHostKeyChecking=no'
      ```
@@ -103,7 +103,7 @@ We will do this from **Concert Workflows** → **Authentications** tab.
    - **Service**: **Config Data**
    - **Data (required)**: Enter the following JSON:
 
-      ```json
+      ```json title="Example Input"
       {
         "config": [
           {
@@ -279,12 +279,12 @@ Additionally, you can verify this on the Linux server.
 
 Run the following command on the Bastion host to connect to the RHEL VM:
 
-```bash
+```bash title="Host: bastion-gym-lan"
 ssh jammer@demo-apps
 ```
 
-After connecting, run the following command, substituing one of the RHSA values that was reported as applied in the previous step:
-```bash
+After connecting, run the following command, substituting one of the RHSA values that was reported as applied in the previous step:
+```bash title="Host: demo-apps"
 sudo dnf updateinfo list installed RHSA-XXXX:XXXX
 ```
 

--- a/labs/concert/vulnerability/3-lab-preparation/index.mdx
+++ b/labs/concert/vulnerability/3-lab-preparation/index.mdx
@@ -28,7 +28,7 @@ This is for information only. Later in this page you will be instructed to run t
 
 Note that from the Bastion SSH, you can ssh into each other VM with the commands below: 
 
-```bash
+```bash title="Host: bastion-gym-lan"
 # Access the Concert VM
 ssh jammer@concert
 # Access the Instana VM
@@ -78,7 +78,7 @@ GHCR_PAT - GitHub Personal Access Token:
 
 From the Bastion SSH, run the command below:
 
-```bash
+```bash title="Host: bastion-gym-lan"
 cat demo-details.yml | grep -E 'concert|instana|jenkins'
 ``` 
 
@@ -139,19 +139,19 @@ DO NOT use these watsonx.ai credentials for any other purpose outside this lab.
 From the Bastion SSH, run the following command to login to the Concert host with the user 'jammer'. If this is your first time connecting, 
 you may need to accept the host key fingerprint.
 
-```bash
+```bash title="Host: bastion-gym-lan"
 ssh jammer@concert
 ```
 Once logged in, run the following command:
 
-```bash
+```bash title="Host: concert"
 export INSTALL_DIR=/opt/ibm/concert/ibm-concert
 ```
 
 Obtain the required credentials for connecting to watsonx.ai. Open [**this Box Note**](https://ibm.box.com/v/concert-vuln-lab), 
 copy the three lines and run them in the Concert host Terminal to set the environment variables. 
 
-```bash
+```bash title="Host: concert"
 # use the exports from the Box Note, they should look similar to this:
 export WATSONX_API_MODEL_ID=
 export WATSONX_API_KEY=... 
@@ -161,7 +161,7 @@ export WATSONX_API_URL=...
 
 Just to confirm the four env. variables are set, run this command and make sure each line shows a value:
 
-```bash
+```bash title="Host: concert"
 echo "INSTALL_DIR=$INSTALL_DIR"
 echo "WATSONX_API_MODEL_ID=$WATSONX_API_MODEL_ID"
 echo "WATSONX_API_KEY=$WATSONX_API_KEY"
@@ -171,7 +171,7 @@ echo "WATSONX_API_URL=$WATSONX_API_URL"
 
 Run the commands below to apply the watsonx.ai configuration into the file **local_config.env**:
 
-```bash
+```bash title="Host: concert"
 echo "WATSONX_API_MODEL_ID=$WATSONX_API_MODEL_ID" >> $INSTALL_DIR/ibm-concert-std/etc/local_config.env
 echo "WATSONX_API_KEY=$WATSONX_API_KEY" >> $INSTALL_DIR/ibm-concert-std/etc/local_config.env
 echo "WATSONX_API_PROJECT_ID=$WATSONX_API_PROJECT_ID" >> $INSTALL_DIR/ibm-concert-std/etc/local_config.env
@@ -184,7 +184,7 @@ Finally, run the two commands below **one by one** to restart the py-utils servi
 In the last **start_service** command, you can ignore one or more warnings **WARN[0000] Failed to mount subscriptions ...**
 :::
 
-```bash
+```bash title="Host: concert"
 $INSTALL_DIR/ibm-concert-std/bin/stop_service ibm-roja-py-utils
 $INSTALL_DIR/ibm-concert-std/bin/start_service ibm-roja-py-utils
 ```

--- a/labs/concert/vulnerability/4-instana-integration/index.mdx
+++ b/labs/concert/vulnerability/4-instana-integration/index.mdx
@@ -83,21 +83,21 @@ We will enable the CVE sensor in the Instana agent that its running in the **blu
 
 From the Bastion SSH, connect to the **bluebox** host:
 
-```bash
+```bash title="Host: bastion-gym-lan"
 ssh jammer@bluebox
 ``` 
 
 We will enable the CVE sensor by updating the agent configuration file.
 First, we will backup the configuration file before making changes. Run the following command:
 
-```bash
+```bash title="Host: bluebox"
 sudo cp /opt/instana/agent/etc/instana/configuration.yaml /opt/instana/agent/etc/instana/configuration.yaml.backup
 ```
 
 Next, we will edit the `configuration.yaml` file to include the Concert CVE sensor configuration.
 Run the following command to open the configuration file in the `vi` editor:
 
-```bash
+```bash title="Host: bluebox"
 sudo vi /opt/instana/agent/etc/instana/configuration.yaml
 ```
 
@@ -128,13 +128,13 @@ Your updated configuration should look similar to the following example (note th
 
 Finally, apply the updated configuration to the Instana agent by running the following command:
 
-```bash
+```bash title="Host: bluebox"
 sudo systemctl restart instana-agent
 ```
 
 Verify the Changes. Check agent status by running the following command. You should see that the agent is active and running:
 
-```bash
+```bash title="Host: bluebox"
 sudo systemctl status instana-agent
 ```
 
@@ -147,7 +147,7 @@ the activation message **Activated Sensor for concertCve**
 :::
 
 
-```bash
+```bash title="Host: bluebox"
 sudo cat /opt/instana/agent/data/log/agent.log |grep -i cve
 ```
 

--- a/labs/concert/vulnerability/5-app-build-deploy/index.mdx
+++ b/labs/concert/vulnerability/5-app-build-deploy/index.mdx
@@ -34,8 +34,11 @@ From a high-level perspective, Buildah is similar to Docker or Podman, but it do
 We will verify now that the application is not deployed yet in the cluster by running the following commands.
 From the Bastion SSH, run the following commands **one by one** to login to the demo-apps VM host with the user 'jammer'.
 
-```bash
+```bash title="Host: bastion-gym-lan"
 ssh jammer@demo-apps
+```
+
+```bash title="Host: demo-apps"
 kubectl get pods -n qotd
 exit
 ```
@@ -225,14 +228,17 @@ After the build is finish, you should see a green check next to the build number
 We will verify now that the application has been deployed in the cluster by running the following commands.
 From the Bastion SSH, run the following commands **one by one**  to login to the demo-apps VM host with the user 'jammer'.
 
-```bash
+```bash title="Host: bastion-gym-lan"
 ssh jammer@demo-apps
+```
+
+```bash title="Host: demo-apps"
 kubectl get pods -n qotd
 exit
 ```
 You should see the following output will all pods with running status:
 
-```bash
+```bash title="Example Output"
 [jammer@demo-apps ~]$ kubectl get pods -n qotd
 NAME                             READY   STATUS    RESTARTS   AGE
 qotd-author-696bcdb947-mvb2d     1/1     Running   0          76m

--- a/labs/concert/vulnerability/6-vulnerability-scanning/index.mdx
+++ b/labs/concert/vulnerability/6-vulnerability-scanning/index.mdx
@@ -260,8 +260,11 @@ poll_rate is 360 minutes (6 hours). Anything lower than 360 minutes is ignored. 
 
 Restart the Instana Agent deployed in the bluebox VM following the same steps described in section 4.3.1
 
-```bash
+```bash title="Host: bastion-gym-lan"
 ssh jammer@bluebox
+```
+
+```bash title="Host: bluebox"
 sudo systemctl restart instana-agent
 sudo systemctl status instana-agent
 ```


### PR DESCRIPTION
(1) corrected formatting for sh or bash code block to include hostname
(2) corrected typo for substituting in `labs/concert/os-patch-management/5-vuln-patch/index.mdx`
