### PR TITLE
Add new AIOps blog enrich from CSV

### DIFF
--- a/best-practice/cloud-pak-for-aiops/blogs/index.mdx
+++ b/best-practice/cloud-pak-for-aiops/blogs/index.mdx
@@ -8,6 +8,10 @@ sidebar_position: 1
 
 This section contains links to AIOps blog posts that practitioners may find useful. This will be updated from time to time with new content as it is published.
 
+**27 Apr 2026**
+[Cloud Pak for AIOps 4 tips: alert enrichment from a CSV](
+https://community.ibm.com/community/user/blogs/zane-bray1/2026/04/27/cloud-pak-for-aiops-4-tips-enrichment-from-csv)
+
 **10 Apr 2026**
 [Cloud Pak for AIOps 4 tips: housekeeping for incidents using Netcool/Impact](
 https://community.ibm.com/community/user/blogs/zane-bray1/2026/04/10/cloud-pak-for-aiops-4-tips-incidents-housekeeping)


### PR DESCRIPTION
I added a new blog post to the AIOps blog:
https://ibm.github.io/waiops-tech-jam/best-practice/cloud-pak-for-aiops/blogs/