### PR TITLE
Add Single Sign-On lab to introduction section

### DIFF
--- a/labs/concert/introduction/index.mdx
+++ b/labs/concert/introduction/index.mdx
@@ -20,6 +20,9 @@ Lab list:
 - [**Vulnerability OS auto-patching**](../os-patch-management/1-introduction/index.mdx)
   - In this Lab, we explore how Concert can trigger a RHEL VM scan, correlate with security advisors and run a patch.
 
+- [**Single Sign-On**](../sso/1-introduction/index.mdx)
+  - In this Lab, we explore how to configure Concert SSO using OpenLDAP as user directory and Keycloak as OIDC provider.
+
 More labs will be added in the future to explore advanced scenarios and features in IBM Concert Protect.
 
 ---


### PR DESCRIPTION
Added a new lab entry for configuring Single Sign-On with OpenLDAP and Keycloak.