### PR TITLE
tweaked useradd command to include password

### DIFF
--- a/labs/cloud-pak-aiops/netcool-install/3-installation/index.mdx
+++ b/labs/cloud-pak-aiops/netcool-install/3-installation/index.mdx
@@ -111,8 +111,9 @@ echo "Creating ncodamin group..."
 groupadd ncoadmin
 
 echo "Creating netcool user..."
-useradd netcool -u 1005
-passwd netcool
+mypwd=`echo netcool | openssl passwd -6 -stdin`
+echo $mypwd
+useradd netcool -u 1005 -p $mypwd
 usermod -g ncoadmin netcool
 
 echo "Changing ownership for /opt..."
@@ -144,7 +145,7 @@ systemctl restart sshd
 
 :::tip
 
-Set the `netcool` password to: `netcool` for this lab.
+The `netcool` user password is set to `netcool` for this lab.
 
 :::
 

--- a/labs/cloud-pak-aiops/netcool-webgui-install/3-installation/index.mdx
+++ b/labs/cloud-pak-aiops/netcool-webgui-install/3-installation/index.mdx
@@ -111,8 +111,9 @@ echo "Creating ncodamin group..."
 groupadd ncoadmin
 
 echo "Creating netcool user..."
-useradd netcool -u 1005
-passwd netcool
+mypwd=`echo netcool | openssl passwd -6 -stdin`
+echo $mypwd
+useradd netcool -u 1005 -p $mypwd
 usermod -g ncoadmin netcool
 
 echo "Changing ownership for /opt..."
@@ -131,7 +132,7 @@ systemctl restart sshd
 
 :::tip
 
-Set the `netcool` password to: `netcool` for this lab.
+The `netcool` user password is set to `netcool` for this lab.
 
 :::
 


### PR DESCRIPTION
I removed the passwd call and instead included the password in the useradd command.
This is updated in both the Netcool OMNIbus/Impact install lab and the Netcool WebGUI install lab.