### PR TITLE
include the setting of the password in the useradd command

### DIFF
--- a/labs/cloud-pak-aiops/netcool-install/3-installation/index.mdx
+++ b/labs/cloud-pak-aiops/netcool-install/3-installation/index.mdx
@@ -111,10 +111,9 @@ echo "Creating ncodamin group..."
 groupadd ncoadmin
 
 echo "Creating netcool user..."
-useradd netcool -u 1005
-passwd netcool
+mypwd=`echo netcool | openssl passwd -6 -stdin`
+useradd netcool -u 1005 -p $mypwd
 usermod -g ncoadmin netcool
-
 echo "Changing ownership for /opt..."
 chown -R netcool:ncoadmin /opt
 

--- a/labs/cloud-pak-aiops/netcool-webgui-install/3-installation/index.mdx
+++ b/labs/cloud-pak-aiops/netcool-webgui-install/3-installation/index.mdx
@@ -111,8 +111,8 @@ echo "Creating ncodamin group..."
 groupadd ncoadmin
 
 echo "Creating netcool user..."
-useradd netcool -u 1005
-passwd netcool
+mypwd=`echo netcool | openssl passwd -6 -stdin`
+useradd netcool -u 1005 -p $mypwd
 usermod -g ncoadmin netcool
 
 echo "Changing ownership for /opt..."


### PR DESCRIPTION
The netcool user is created as a part of this lab.
The instructions have been tweaked to set the password as part of the useradd command, rather than making the user type in the password: "netcool".